### PR TITLE
fix: onSelectEmoji is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ export default {
             });
 
             Unpatch.emojiPickerModule = patcher.patch(emojiPickerModule, "useEmojiSelectHandler", (originalArgs, previousReturn) => {
-                const { onSelectEmoji, closePopout } = originalArgs;
+                const { onSelectEmoji, closePopout } = originalArgs[0];
                 return function (data, state) {
                   const emoji = data.emoji;
                   if (emoji != null && emoji.available) {


### PR DESCRIPTION
i could not reproduce #1 but it should be related to this.

more context: emoji picker did not work correctly due to the error above, upon investigating turns out it returns an object, the functions being contained in the first entry inside of that, this tiny fix solves that and the emoji picker works fully again.